### PR TITLE
Fixed #16 Issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,10 @@ div.character-bg {
 }
 
 .home-img {
+  object-fit: contain;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: 300px;
 }
 
@@ -221,6 +225,13 @@ div.character-bg {
 .btn:focus {
   box-shadow: 0 0.8em 0.8em -0.4em black;
   transform: translateY(-0.25em);
+}
+
+@media only screen and (min-width: 580px) and (max-width: 1050px) {
+  .col-sm {
+    padding-left: 5px !important;
+    padding-right: 5px !important;
+  }
 }
 
 @media only screen and (max-width: 580px) {


### PR DESCRIPTION
**Fixes**:- Issue #16 

**Changes Done**:- The images were getting distorted on lower resolutions on the PC because the object-fit was applied only to mobile resolutions. I have now applied object-fit to all resolutions introducing a new media query specific to lower resolutions of pc. This media query ensures the extra padding present on left and right of images in the intermediate resolutions is reduced down to 5px so that extra spacing could be avoided 

**How to Test**:- On inspecting and opening responsive tab, for lower resolutions on PC, the images would not lose their aspect ratio.

**Extra Information**:-
![2021-09-29 (19)](https://user-images.githubusercontent.com/82700547/135309104-dcc23eb2-fae8-4c41-8fcd-236372a4c1a1.png)
![2021-09-29 (20)](https://user-images.githubusercontent.com/82700547/135309121-42aef9a8-21cc-4f0e-a867-760991b3e935.png)
 
