### PR TITLE
Fixed Issue #18

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -240,6 +240,9 @@ div.character-bg {
     .row{
       flex-direction: column;
     }
+    .play{
+      flex-direction: column-reverse;
+    }
     .justify-content-end {
       justify-content: center !important;
       align-items: center;

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ permalink: /
     </div>
 
     <!-- Play -->
-    <div class="row hover-shadow">
+    <div class="row hover-shadow play">
       <div class="col-sm p-5">
         <img src="/img/home_projects.png" class="img-fluid home-img" />
       </div>


### PR DESCRIPTION
The second image for the lower resolutions is arranged same as the other two images

**Fixes**:- #18

**Changes Done**:- Added a class to the second div on the home page and reversed the flex direction for lower resolutions

**How to Test**:- The second image is arranged like others on mobile now.

**Extra Information**:-
![2021-10-25](https://user-images.githubusercontent.com/82700547/138739494-def178f5-7247-4372-beac-e86206215523.png)
![2021-10-25 (1)](https://user-images.githubusercontent.com/82700547/138739498-45439086-e929-4ec8-bd67-e70707290b5e.png)
 
